### PR TITLE
[ZWEED-007-restructure] Move translation code from root directory into its own directory

### DIFF
--- a/analysis/engine.py
+++ b/analysis/engine.py
@@ -1,17 +1,11 @@
 import re
 
-from transformers import TFAutoModelForSeq2SeqLM
-from transformers import AutoTokenizer
+from analysis.translation import Translation
 from analysis.morpheme import Morpheme
 from nltk.sentiment import *
 from textblob import TextBlob
 
 class Engine:
-  def __init__(self):
-    self.engine = SentimentIntensityAnalyzer()
-
-  # Aliased polarity scores, as aggregates
-  # of overall sentiment from sentence.
   def score(self, data):
     return TextBlob(data).sentiment.polarity
 
@@ -25,14 +19,5 @@ class Engine:
     return Morpheme(data).noun_phrases
 
   def translate(self, data):
-    string = re.search("(.*):(.*)", data)
-    # Represents like 'please translate from:'
-    translation_request = string[1]
-    # Represents what to translate
-    for_translation = string[2]
-    tokenizer = AutoTokenizer.from_pretrained("t5-base")
-    translation_model = TFAutoModelForSeq2SeqLM.from_pretrained("t5-base")
-    inputs = tokenizer(f"{translation_request}: {for_translation}", return_tensors="tf").input_ids
-    outputs = translation_model.generate(inputs)
-    return tokenizer.decode(outputs[0], skip_special_tokens=True)
+    return Translation(data).translate
 

--- a/analysis/translation.py
+++ b/analysis/translation.py
@@ -1,0 +1,22 @@
+import re
+
+from transformers import TFAutoModelForSeq2SeqLM
+from transformers import AutoTokenizer
+from textblob import TextBlob
+
+class Translation:
+  def __init__(self, data):
+    self.data = data
+    self.tokenizer = AutoTokenizer.from_pretrained("t5-base")
+    self.translation_model = TFAutoModelForSeq2SeqLM.from_pretrained("t5-base")
+
+  def build_query_string(self, data):
+    string = re.search("(.*):(.*)", self.data)
+    return [string[1], string[2]]
+
+  def translate(self):
+    query_string = self.build_query_string(self.data)
+    inputs = self.tokenizer(f"{query_string[0]}: {query_string[1]}", return_tensors="tf").input_ids
+    outputs = self.translation_model.generate(inputs)
+    return self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+

--- a/comms.py
+++ b/comms.py
@@ -17,5 +17,4 @@ class Comms:
     return Morpheme(data).noun_phrases
 
   def translate(self, data):
-    print(f"in translate")
     return Engine().translate(data)

--- a/comms.py
+++ b/comms.py
@@ -1,0 +1,21 @@
+import sys
+import nltk
+
+from analysis.engine import Engine
+from analysis.morpheme import Morpheme
+
+for dep in ["vader_lexicon", "punkt", "brown"]: nltk.download(dep)
+
+class Comms:
+  def polarity(self, data):
+    return Engine().score(data)
+
+  def sentiment(self, data):
+    return Engine().analyze_sentiment(data)
+
+  def nouns(self, data):
+    return Morpheme(data).noun_phrases
+
+  def translate(self, data):
+    print(f"in translate")
+    return Engine().translate(data)


### PR DESCRIPTION
### Summary
Originally the code for translation was handled directly within `Engine` and this lead to bloated code. The purpose of this is moving this code within a `Translation` class.